### PR TITLE
✨ add parser for `.real` files

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -35,7 +35,7 @@ endif()
 # cmake-format: off
 set(MQT_CORE_VERSION 3.0.0
     CACHE STRING "MQT Core version")
-set(MQT_CORE_REV "8b25b61666cef507ad8920bd997627d6d348231d"
+set(MQT_CORE_REV "be654c753e98e9062d796143dd3a591366370b2d"
     CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
 set(MQT_CORE_REPO_OWNER "cda-tum"
 	CACHE STRING "MQT Core repository owner (change when using a fork)")

--- a/include/core/real/parser.hpp
+++ b/include/core/real/parser.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ir/QuantumComputation.hpp"
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+
+namespace syrec {
+
+    class RealParser {
+    public:
+        [[nodiscard]] static auto imports(const std::string& realString) -> qc::QuantumComputation;
+        [[nodiscard]] static auto importf(const std::string& filename) -> qc::QuantumComputation;
+        [[nodiscard]] static auto import(std::istream& is) -> qc::QuantumComputation;
+
+    private:
+        RealParser() = default;
+        explicit RealParser(qc::QuantumComputation& circ):
+            qc(&circ) {}
+
+        qc::QuantumComputation* qc;
+        size_t                  nqubits{0};
+        size_t                  nclassics{0};
+
+        [[nodiscard]] auto readRealHeader(std::istream& is) -> int;
+        auto               readRealGateDescriptions(std::istream& is, int line) const -> void;
+    };
+} // namespace syrec

--- a/include/core/real/parser.hpp
+++ b/include/core/real/parser.hpp
@@ -19,7 +19,7 @@ namespace syrec {
         explicit RealParser(qc::QuantumComputation& circ):
             qc(&circ) {}
 
-        qc::QuantumComputation* qc;
+        qc::QuantumComputation* qc{};
         size_t                  nqubits{0};
         size_t                  nclassics{0};
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "scikit-build-core>=0.10.7",
     "setuptools-scm>=8.1",
     "pybind11>=2.13.6",
-    "mqt.core>=3.0.0b3",
+    "mqt.core>=3.0.0b4",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -40,7 +40,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "mqt.core>=3.0.0b3",
+    "mqt.core>=3.0.0b4",
     "PyQt6>=6.8",
 ]
 dynamic = ["version"]
@@ -275,10 +275,8 @@ environment = { DEPLOY="ON" }
 # The SOVERSION needs to be updated when the shared libraries are updated.
 repair-wheel-command = """auditwheel repair -w {dest_dir} {wheel} \
 --exclude libmqt-core-ir.so.3.0 \
---exclude libmqt-core-circuit-optimizer.so.3.0 \
---exclude libmqt-core-algorithms.so.3.0 \
---exclude libmqt-core-dd.so.3.0 \
---exclude libmqt-core-zx.so.3.0"""
+--exclude libmqt-core-qasm.so.3.0 \
+--exclude libmqt-core-dd.so.3.0"""
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
@@ -288,10 +286,8 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 before-build = "uv pip install delvewheel>=1.9.0"
 repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt \
 --exclude mqt-core-ir.dll \
---exclude mqt-core-circuit-optimizer.dll \
---exclude mqt-core-algorithms.dll \
---exclude mqt-core-dd.dll \
---exclude mqt-core-zx.dll"""
+--exclude mqt-core-qasm.dll \
+--exclude mqt-core-dd.dll"""
 environment = { CMAKE_ARGS = "-T ClangCL" }
 
 [[tool.cibuildwheel.overrides]]
@@ -312,7 +308,7 @@ build = [
     "pybind11>=2.13.6",
     "scikit-build-core>=0.10.7",
     "setuptools-scm>=8.1",
-    "mqt-core>=3.0.0b3",
+    "mqt-core>=3.0.0b4",
 ]
 docs = [
     "furo>=2024.8.6",

--- a/src/core/real/parser.cpp
+++ b/src/core/real/parser.cpp
@@ -21,6 +21,8 @@
 #include <optional>
 #include <regex>
 #include <set>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -476,12 +478,6 @@ namespace syrec {
                         }
 
                         qc->setLogicalQubitAncillary(ancillaryQubit);
-
-                        // Since the call to setLogicalQubitAncillary does not actually
-                        // transfer the qubit from the data qubit register into the ancillary
-                        // register we will 'manually' perform this transfer.
-                        const std::string associatedVariableNameForQubitRegister =
-                                qc->getQubitRegister(ancillaryQubit).getName();
                     } else if (constantValuePerIo != '-') {
                         throw std::runtime_error("[real parser] l:" + std::to_string(line) +
                                                  " msg: Invalid value in '.constants' header: '" +

--- a/src/core/real/parser.cpp
+++ b/src/core/real/parser.cpp
@@ -1,0 +1,864 @@
+#include "core/real/parser.hpp"
+
+#include "Definitions.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/Register.hpp"
+#include "ir/operations/Control.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/StandardOperation.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <istream>
+#include <limits>
+#include <map>
+#include <optional>
+#include <regex>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace syrec {
+    namespace {
+        std::optional<qc::Qubit> getQubitForVariableIdentFromAnyLookup(
+                const std::string& variableIdent, const qc::QuantumRegisterMap& dataQubits,
+                const qc::QuantumRegisterMap& ancillaryQubits) {
+            if (const auto& matchingEntryInDataQubits = dataQubits.find(variableIdent);
+                matchingEntryInDataQubits != dataQubits.end()) {
+                return matchingEntryInDataQubits->second.getStartIndex();
+            }
+
+            if (const auto& matchingEntryInAncillaryQubits =
+                        ancillaryQubits.find(variableIdent);
+                matchingEntryInAncillaryQubits != ancillaryQubits.end()) {
+                return matchingEntryInAncillaryQubits->second.getStartIndex();
+            }
+
+            return std::nullopt;
+        }
+
+        /// Determine whether the given io name value, which is not enclosed in quotes,
+        /// consists of only letters, digits, and underscore characters.
+        /// @param ioName The name to validate
+        /// @return Whether the given io name is valid
+        bool isValidIoName(const std::string_view& ioName) noexcept {
+            return !ioName.empty() &&
+                   std::all_of(
+                           ioName.cbegin(), ioName.cend(), [](const char ioNameCharacter) {
+                               return static_cast<bool>(std::isalnum(
+                                              static_cast<unsigned char>(ioNameCharacter))) ||
+                                      ioNameCharacter == '_';
+                           });
+        }
+
+        std::vector<std::string>
+        parseVariableNames(const int                              processedLineNumberInRealFile,
+                           const std::size_t                      expectedNumberOfVariables,
+                           const std::string&                     readInRawVariableIdentValues,
+                           const std::unordered_set<std::string>& variableIdentsLookup,
+                           const std::string_view&                trimableVariableIdentPrefix) {
+            std::vector<std::string> variableNames;
+            variableNames.reserve(expectedNumberOfVariables);
+
+            std::unordered_set<std::string> processedVariableIdents;
+            std::size_t                     variableIdentStartIdx = 0;
+            std::size_t                     variableIdentEndIdx   = 0;
+
+            while (variableIdentStartIdx < readInRawVariableIdentValues.size() &&
+                   variableNames.size() < expectedNumberOfVariables) {
+                variableIdentEndIdx =
+                        readInRawVariableIdentValues.find_first_of(' ', variableIdentStartIdx);
+
+                if (variableIdentEndIdx == std::string::npos) {
+                    variableIdentEndIdx = readInRawVariableIdentValues.size();
+                }
+
+                std::size_t variableIdentLength =
+                        variableIdentEndIdx - variableIdentStartIdx;
+
+                // Remove carriage return character if present
+                if (variableIdentLength > 0 &&
+                    readInRawVariableIdentValues.at(variableIdentEndIdx - 1) == '\r') {
+                    --variableIdentLength;
+                }
+
+                auto variableIdent = readInRawVariableIdentValues.substr(
+                        variableIdentStartIdx, variableIdentLength);
+                const bool trimVariableIdent =
+                        variableIdent.find_first_of(trimableVariableIdentPrefix) == 0;
+                if (trimVariableIdent) {
+                    variableIdent =
+                            variableIdent.replace(0, trimableVariableIdentPrefix.size(), "");
+                }
+
+                if (!isValidIoName(variableIdent)) {
+                    throw std::runtime_error(
+                            "[real parser] l: " + std::to_string(processedLineNumberInRealFile) +
+                            " msg: invalid variable name: " + variableIdent);
+                }
+
+                if (processedVariableIdents.count(variableIdent) > 0) {
+                    throw std::runtime_error(
+                            "[real parser] l: " + std::to_string(processedLineNumberInRealFile) +
+                            " msg: duplicate variable name: " + variableIdent);
+                }
+
+                if (!variableIdentsLookup.empty() &&
+                    variableIdentsLookup.count(variableIdent) == 0) {
+                    throw std::runtime_error(
+                            "[real parser] l: " + std::to_string(processedLineNumberInRealFile) +
+                            " msg: given variable name " + variableIdent +
+                            " was not declared in .variables entry");
+                }
+                processedVariableIdents.emplace(variableIdent);
+                variableNames.emplace_back(trimVariableIdent ? std::string(trimableVariableIdentPrefix) +
+                                                                       variableIdent :
+                                                               variableIdent);
+                variableIdentStartIdx = variableIdentEndIdx + 1;
+            }
+
+            if (variableIdentEndIdx < readInRawVariableIdentValues.size() &&
+                readInRawVariableIdentValues.at(variableIdentEndIdx) == ' ') {
+                throw std::runtime_error(
+                        "[real parser] l: " + std::to_string(processedLineNumberInRealFile) +
+                        " msg: expected only " + std::to_string(expectedNumberOfVariables) +
+                        " variable identifiers to be declared but variable identifier "
+                        "delimiter was found"
+                        " after " +
+                        std::to_string(expectedNumberOfVariables) +
+                        " identifiers were detected (which we assume will be followed by "
+                        "another io identifier)!");
+            }
+
+            if (variableNames.size() < expectedNumberOfVariables) {
+                throw std::runtime_error(
+                        "[real parser] l:" + std::to_string(processedLineNumberInRealFile) +
+                        " msg: Expected " + std::to_string(expectedNumberOfVariables) +
+                        " variable idents but only " + std::to_string(variableNames.size()) +
+                        " were declared!");
+            }
+            return variableNames;
+        }
+
+        std::unordered_map<std::string, qc::Qubit>
+        parseIoNames(const int                              lineInRealFileDefiningIoNames,
+                     const std::size_t                      expectedNumberOfIos,
+                     const std::string&                     ioNameIdentsRawValues,
+                     const std::unordered_set<std::string>& variableIdentLookup) {
+            std::unordered_map<std::string, qc::Qubit> foundIoNames;
+            std::size_t                                ioNameStartIdx = 0;
+            std::size_t                                ioNameEndIdx   = 0;
+            std::size_t                                ioIdx          = 0;
+
+            bool searchingForWhitespaceCharacter = false;
+            while (ioNameStartIdx < ioNameIdentsRawValues.size() &&
+                   foundIoNames.size() <= expectedNumberOfIos) {
+                searchingForWhitespaceCharacter =
+                        ioNameIdentsRawValues.at(ioNameStartIdx) != '"';
+                if (searchingForWhitespaceCharacter) {
+                    ioNameEndIdx = ioNameIdentsRawValues.find_first_of(' ', ioNameStartIdx);
+                } else {
+                    ioNameEndIdx =
+                            ioNameIdentsRawValues.find_first_of('"', ioNameStartIdx + 1);
+                }
+
+                if (ioNameEndIdx == std::string::npos) {
+                    ioNameEndIdx = ioNameIdentsRawValues.size();
+                    if (!searchingForWhitespaceCharacter) {
+                        throw std::runtime_error(
+                                "[real parser] l: " +
+                                std::to_string(lineInRealFileDefiningIoNames) +
+                                " no matching closing quote found for name of io: " +
+                                std::to_string(ioIdx));
+                    }
+                } else {
+                    ioNameEndIdx +=
+                            static_cast<std::size_t>(!searchingForWhitespaceCharacter);
+                }
+
+                std::size_t ioNameLength = ioNameEndIdx - ioNameStartIdx;
+                // Remove carriage return character if present
+                if (ioNameLength > 0 &&
+                    ioNameIdentsRawValues.at(ioNameEndIdx - 1) == '\r') {
+                    --ioNameLength;
+                }
+
+                const auto& ioName =
+                        ioNameIdentsRawValues.substr(ioNameStartIdx, ioNameLength);
+
+                std::string_view ioNameToValidate = ioName;
+                if (!searchingForWhitespaceCharacter) {
+                    ioNameToValidate =
+                            ioNameToValidate.substr(1, ioNameToValidate.size() - 2);
+                }
+
+                if (!isValidIoName(ioNameToValidate)) {
+                    throw std::runtime_error(
+                            "[real parser] l: " + std::to_string(lineInRealFileDefiningIoNames) +
+                            " msg: invalid io name: " + ioName);
+                }
+
+                if (variableIdentLookup.count(ioName) > 0) {
+                    throw std::runtime_error(
+                            "[real parser] l: " + std::to_string(lineInRealFileDefiningIoNames) +
+                            " msg: IO ident matched already declared variable with name " +
+                            ioName);
+                }
+
+                ioNameStartIdx = ioNameEndIdx + 1;
+                if (const auto& ioNameInsertionIntoLookupResult =
+                            foundIoNames.emplace(ioName, static_cast<qc::Qubit>(ioIdx++));
+                    !ioNameInsertionIntoLookupResult.second) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(lineInRealFileDefiningIoNames) +
+                            " msg: duplicate io name: " + ioName);
+                }
+            }
+
+            if (searchingForWhitespaceCharacter &&
+                ioNameEndIdx + 1 < ioNameIdentsRawValues.size() &&
+                ioNameIdentsRawValues.at(ioNameEndIdx + 1) == ' ') {
+                throw std::runtime_error(
+                        "[real parser] l:" + std::to_string(lineInRealFileDefiningIoNames) +
+                        " msg: expected only " + std::to_string(expectedNumberOfIos) +
+                        " io identifiers to be declared but io identifier delimiter was found"
+                        " after " +
+                        std::to_string(expectedNumberOfIos) +
+                        " identifiers were detected (which we assume will be followed by "
+                        "another io identifier)!");
+            }
+            return foundIoNames;
+        }
+
+        void assertRequiredHeaderComponentsAreDefined(
+                const int                               processedLine,
+                std::initializer_list<std::string_view> requiredHeaderComponentPrefixes,
+                const std::set<std::string, std::less<>>&
+                        currentUserDeclaredHeaderComponents) {
+            for (const auto& requiredHeaderComponentPrefix:
+                 requiredHeaderComponentPrefixes) {
+                if (currentUserDeclaredHeaderComponents.count(
+                            requiredHeaderComponentPrefix) == 0) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(processedLine) +
+                            " msg: Expected " + std::string(requiredHeaderComponentPrefix) +
+                            " to have been already defined");
+                }
+            }
+        }
+
+        void trimCommentAndTrailingWhitespaceData(std::string& lineToProcess) {
+            if (const auto commentLinePrefixPosition = lineToProcess.find_first_of('#');
+                commentLinePrefixPosition != std::string::npos) {
+                if (commentLinePrefixPosition != 0) {
+                    lineToProcess = lineToProcess.substr(0, commentLinePrefixPosition);
+                } else {
+                    lineToProcess = "";
+                }
+            }
+
+            if (lineToProcess.empty()) {
+                return;
+            }
+
+            if (const std::size_t positionOfLastDataCharacter =
+                        lineToProcess.find_last_not_of(" \t");
+                positionOfLastDataCharacter != std::string::npos &&
+                positionOfLastDataCharacter != lineToProcess.size() - 1) {
+                lineToProcess = lineToProcess.substr(0, positionOfLastDataCharacter + 1);
+            }
+        }
+    } // namespace
+
+    using namespace qc;
+
+    auto RealParser::imports(const std::string& realString) -> QuantumComputation {
+        std::istringstream iss(realString);
+        return import(iss);
+    }
+
+    auto RealParser::importf(const std::string& filename) -> QuantumComputation {
+        std::ifstream ifs(filename);
+        if (!ifs.good()) {
+            throw std::runtime_error("[real parser] msg: Failed to open file " + filename);
+        }
+        return import(ifs);
+    }
+
+    auto RealParser::import(std::istream& is) -> QuantumComputation {
+        QuantumComputation qc;
+        RealParser         parser(qc);
+        const auto         line = parser.readRealHeader(is);
+        parser.readRealGateDescriptions(is, line);
+        return qc;
+    }
+
+    int RealParser::readRealHeader(std::istream& is) {
+        std::string cmd;
+        int         line = 0;
+
+        // We could reuse the QuantumRegisterMap type defined in the qc namespace but
+        // to avoid potential errors due to any future refactoring of said type, we
+        // use an std::unordered_map instead
+        std::unordered_map<std::string, Qubit> userDefinedInputIdents;
+        std::unordered_map<std::string, Qubit> userDefinedOutputIdents;
+        std::unordered_set<std::string>        userDeclaredVariableIdents;
+        std::unordered_set<Qubit>              outputQubitsMarkedAsGarbage;
+
+        constexpr std::string_view numVariablesHeaderComponentPrefix = ".NUMVARS";
+        constexpr std::string_view variablesHeaderComponentPrefix    = ".VARIABLES";
+        constexpr std::string_view outputsHeaderComponentPrefix      = ".OUTPUTS";
+
+        std::set<std::string, std::less<>> definedHeaderComponents;
+
+        while (true) {
+            if (!static_cast<bool>(is >> cmd)) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Invalid file header");
+            }
+            std::transform(cmd.begin(), cmd.end(), cmd.begin(), [](unsigned char ch) {
+                return static_cast<char>(toupper(ch));
+            });
+            ++line;
+
+            // skip comments
+            if (cmd.front() == '#') {
+                is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                continue;
+            }
+
+            // valid header commands start with '.'
+            if (cmd.front() != '.') {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Invalid file header");
+            }
+
+            if (definedHeaderComponents.count(cmd) != 0) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Duplicate definition of header component " +
+                                         cmd);
+            }
+
+            definedHeaderComponents.emplace(cmd);
+            if (cmd == ".BEGIN") {
+                // Entries .numvars and .variables must be declared in all .real files
+                assertRequiredHeaderComponentsAreDefined(
+                        line,
+                        {numVariablesHeaderComponentPrefix, variablesHeaderComponentPrefix},
+                        definedHeaderComponents);
+
+                // The garbage declarations in the .real file are defined on the outputs
+                // while the garbage state of the quantum computation operates on the
+                // defined inputs, thus we perform a mapping from the output marked as
+                // garbage back to the input using the output permutation.
+                auto& garbage = qc->getGarbage();
+                for (const auto& outputQubitMarkedAsGarbage:
+                     outputQubitsMarkedAsGarbage) {
+                    // Since the call setLogicalQubitAsGarbage(...) assumes that the qubit
+                    // parameter is an input qubit, we need to manually mark the output
+                    // qubit as garbage by using the output qubit instead.
+                    for (const auto& [inputQubit, outputQubit]: qc->outputPermutation) {
+                        if (outputQubit == outputQubitMarkedAsGarbage) {
+                            garbage[inputQubit] = true;
+                            break;
+                        }
+                    }
+                    qc->outputPermutation.erase(outputQubitMarkedAsGarbage);
+                }
+
+                // header read complete
+                return line;
+            }
+
+            if (cmd == ".NUMVARS") {
+                if (std::size_t nq{}; !static_cast<bool>(is >> nq)) {
+                    nqubits = 0;
+                } else {
+                    nqubits = nq;
+                }
+                nclassics = nqubits;
+            } else if (cmd == ".VARIABLES") {
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line, {numVariablesHeaderComponentPrefix}, definedHeaderComponents);
+                userDeclaredVariableIdents.reserve(nclassics);
+
+                std::string variableDefinitionEntry;
+                if (!std::getline(is, variableDefinitionEntry)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.variables' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(variableDefinitionEntry);
+                const auto& processedVariableIdents =
+                        parseVariableNames(line, nclassics, variableDefinitionEntry, {}, "");
+                userDeclaredVariableIdents.insert(processedVariableIdents.cbegin(),
+                                                  processedVariableIdents.cend());
+
+                for (std::size_t i = 0; i < nclassics; ++i) {
+                    const std::string& quantumRegisterIdentifier =
+                            processedVariableIdents.at(i);
+                    qc->addQubitRegister(1, quantumRegisterIdentifier);
+
+                    const std::string& classicalRegisterIdentifier =
+                            "c_" + quantumRegisterIdentifier;
+                    qc->addClassicalRegister(1, classicalRegisterIdentifier);
+                }
+            } else if (cmd == ".INITIAL_LAYOUT") {
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line,
+                        {numVariablesHeaderComponentPrefix, variablesHeaderComponentPrefix},
+                        definedHeaderComponents);
+
+                std::string initialLayoutDefinitionEntry;
+                if (!std::getline(is, initialLayoutDefinitionEntry)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.initial_layout' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(initialLayoutDefinitionEntry);
+                const auto& processedVariableIdents =
+                        parseVariableNames(line, nclassics, initialLayoutDefinitionEntry,
+                                           userDeclaredVariableIdents, "");
+
+                // Map the user declared variable idents in the .variable entry to the
+                // ones declared in the .initial_layout as explained in
+                // https://mqt.readthedocs.io/projects/core/en/latest/mqt_core_ir.html#layout-information
+                const auto& quantumRegisters = qc->getQuantumRegisters();
+                for (std::size_t i = 0; i < nclassics; ++i) {
+                    const auto algorithmicQubit = static_cast<Qubit>(i);
+                    const auto deviceQubitForVariableIdentInInitialLayout =
+                            quantumRegisters.at(processedVariableIdents.at(i)).getStartIndex();
+                    qc->initialLayout[deviceQubitForVariableIdentInInitialLayout] =
+                            algorithmicQubit;
+                }
+            } else if (cmd == ".CONSTANTS") {
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line, {numVariablesHeaderComponentPrefix}, definedHeaderComponents);
+
+                std::string constantsValuePerIoDefinition;
+                if (!std::getline(is, constantsValuePerIoDefinition)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.constants' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(constantsValuePerIoDefinition);
+                if (constantsValuePerIoDefinition.size() != nclassics) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(line) + " msg: Expected " +
+                            std::to_string(nclassics) + " constant values but " +
+                            std::to_string(constantsValuePerIoDefinition.size()) +
+                            " were declared!");
+                }
+
+                std::size_t constantValueIdx = 0;
+                for (const auto constantValuePerIo: constantsValuePerIoDefinition) {
+                    if (const bool isCurrentQubitMarkedAsAncillary =
+                                constantValuePerIo == '0' || constantValuePerIo == '1';
+                        isCurrentQubitMarkedAsAncillary) {
+                        const auto& ancillaryQubit = static_cast<Qubit>(constantValueIdx);
+                        // Since ancillary qubits are assumed to have an initial value of
+                        // zero, we need to add an inversion gate to derive the correct
+                        // initial value of 1.
+                        if (constantValuePerIo == '1') {
+                            qc->x(ancillaryQubit);
+                        }
+
+                        qc->setLogicalQubitAncillary(ancillaryQubit);
+
+                        // Since the call to setLogicalQubitAncillary does not actually
+                        // transfer the qubit from the data qubit register into the ancillary
+                        // register we will 'manually' perform this transfer.
+                        const std::string associatedVariableNameForQubitRegister =
+                                qc->getQubitRegister(ancillaryQubit).getName();
+                    } else if (constantValuePerIo != '-') {
+                        throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                                 " msg: Invalid value in '.constants' header: '" +
+                                                 std::to_string(constantValuePerIo) + "'");
+                    }
+                    ++constantValueIdx;
+                }
+            } else if (cmd == ".GARBAGE") {
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line, {numVariablesHeaderComponentPrefix}, definedHeaderComponents);
+
+                std::string garbageStatePerIoDefinition;
+                if (!std::getline(is, garbageStatePerIoDefinition)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.garbage' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(garbageStatePerIoDefinition);
+                if (garbageStatePerIoDefinition.size() != nclassics) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Expected " + std::to_string(nclassics) +
+                                             " garbage state values but " +
+                                             std::to_string(garbageStatePerIoDefinition.size()) +
+                                             " were declared!");
+                }
+
+                std::size_t garbageStateIdx = 0;
+                for (const auto garbageStateValue: garbageStatePerIoDefinition) {
+                    if (const bool isCurrentQubitMarkedAsGarbage = garbageStateValue == '1';
+                        isCurrentQubitMarkedAsGarbage) {
+                        outputQubitsMarkedAsGarbage.emplace(
+                                static_cast<Qubit>(garbageStateIdx));
+                    } else if (garbageStateValue != '-') {
+                        throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                                 " msg: Invalid value in '.garbage' header: '" +
+                                                 std::to_string(garbageStateValue) + "'");
+                    }
+                    garbageStateIdx++;
+                }
+            } else if (cmd == ".INPUTS") {
+                // .INPUT: specifies initial layout
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line,
+                        {numVariablesHeaderComponentPrefix, variablesHeaderComponentPrefix},
+                        definedHeaderComponents);
+
+                if (definedHeaderComponents.count(outputsHeaderComponentPrefix) > 0) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(line) +
+                            " msg: .inputs entry must be declared prior to the .outputs entry");
+                }
+
+                const std::size_t expectedNumInputIos = nclassics;
+                std::string       ioNameIdentsLine;
+                if (!std::getline(is, ioNameIdentsLine)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.inputs' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(ioNameIdentsLine);
+                userDefinedInputIdents =
+                        parseIoNames(line, expectedNumInputIos, ioNameIdentsLine,
+                                     userDeclaredVariableIdents);
+
+                if (userDefinedInputIdents.size() != expectedNumInputIos) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(line) + "msg: Expected " +
+                            std::to_string(expectedNumInputIos) + " inputs to be declared!");
+                }
+            } else if (cmd == ".OUTPUTS") {
+                // .OUTPUTS: specifies output permutation
+                is >> std::ws;
+                assertRequiredHeaderComponentsAreDefined(
+                        line,
+                        {numVariablesHeaderComponentPrefix, variablesHeaderComponentPrefix},
+                        definedHeaderComponents);
+
+                const std::size_t expectedNumOutputIos = nclassics;
+                std::string       ioNameIdentsLine;
+                if (!std::getline(is, ioNameIdentsLine)) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Failed read in '.outputs' line");
+                }
+
+                trimCommentAndTrailingWhitespaceData(ioNameIdentsLine);
+                userDefinedOutputIdents =
+                        parseIoNames(line, expectedNumOutputIos, ioNameIdentsLine,
+                                     userDeclaredVariableIdents);
+
+                if (userDefinedOutputIdents.size() != expectedNumOutputIos) {
+                    throw std::runtime_error(
+                            "[real parser] l:" + std::to_string(line) + "msg: Expected " +
+                            std::to_string(expectedNumOutputIos) + " outputs to be declared!");
+                }
+
+                if (userDefinedInputIdents.empty()) {
+                    continue;
+                }
+
+                for (const auto& [outputIoIdent, outputIoQubit]:
+                     userDefinedOutputIdents) {
+                    // We assume that a permutation of a given input qubit Q at index i
+                    // is performed in the circuit if an entry in both in the .output
+                    // as well as the .input definition using the same literal is found,
+                    // with the input literal being defined at position i in the .input
+                    // definition. If no such matching is found, we require that the output
+                    // is marked as garbage.
+                    //
+                    // The outputPermutation map will use be structured as shown in the
+                    // documentation
+                    // (https://mqt.readthedocs.io/projects/core/en/latest/mqt_core_ir.html#layout-information)
+                    // with the output qubit being used as the key while the input qubit
+                    // serves as the map entries value.
+                    //
+                    if (userDefinedInputIdents.count(outputIoIdent) == 0) {
+                        // The current implementation requires that the .garbage definition is
+                        // define prior to the .output one.
+                        if (outputQubitsMarkedAsGarbage.count(outputIoQubit) == 0) {
+                            throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                                     " msg: outputs without matching inputs are "
+                                                     "expected to be marked as garbage");
+                        }
+                    } else if (const Qubit matchingInputQubitForOutputLiteral =
+                                       userDefinedInputIdents.at(outputIoIdent);
+                               matchingInputQubitForOutputLiteral != outputIoQubit &&
+                               !qc->logicalQubitIsGarbage(outputIoQubit)) {
+                        // We do not need to check whether a mapping from one input to any
+                        // output exists, since we require that the idents defined in either
+                        // of the .input as well as the .output definition are unique in their
+                        // definition.
+                        //
+                        // Only if the matching entries where defined at different indices
+                        // in their respective IO declaration do we update the existing
+                        // identity mapping for the given output qubit
+                        qc->outputPermutation.insert_or_assign(
+                                outputIoQubit, matchingInputQubitForOutputLiteral);
+
+                        // If we have determined a non-identity permutation of an input qubit,
+                        // (i.e. output 2 <- input 1) any existing identity permutation
+                        // of the input qubit will be removed since the previously mapped to
+                        // output (output 1) of the identity permutation must have another
+                        // non-identity permutation defined or must be declared as a garbage
+                        // output.
+                        if (qc->outputPermutation.count(matchingInputQubitForOutputLiteral) > 0 &&
+                            qc->outputPermutation[matchingInputQubitForOutputLiteral] ==
+                                    matchingInputQubitForOutputLiteral) {
+                            qc->outputPermutation.erase(matchingInputQubitForOutputLiteral);
+                        }
+                    }
+                }
+            } else if (cmd == ".VERSION" || cmd == ".INPUTBUS" || cmd == ".OUTPUTBUS") {
+                is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            } else if (cmd == ".DEFINE") {
+                // TODO: Defines currently not supported
+                std::cerr << "[WARN] File contains 'define' statement, which is "
+                             "currently not supported and thus simply skipped.\n";
+                while (cmd != ".ENDDEFINE") {
+                    is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                    is >> cmd;
+                    std::transform(cmd.begin(), cmd.end(), cmd.begin(),
+                                   [](const unsigned char c) {
+                                       return static_cast<char>(toupper(c));
+                                   });
+                }
+            } else {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Unknown command: " + cmd);
+            }
+        }
+    }
+
+    void RealParser::readRealGateDescriptions(std::istream& is,
+                                              int           line) const {
+        const std::regex gateRegex =
+                std::regex("(r[xyz]|i[df]|q|[0a-z](?:[+ip])?)(\\d+)?(?::([-+]?[0-9]+[.]?["
+                           "0-9]*(?:[eE][-+]?[0-9]+)?))?");
+        std::smatch m;
+        std::string cmd;
+
+        static const std::map<std::string, OpType> IDENTIFIER_MAP{
+                {"0", I}, {"id", I}, {"h", H}, {"n", X}, {"c", X}, {"x", X}, {"y", Y}, {"z", Z}, {"s", S}, {"si", Sdg}, {"sp", Sdg}, {"s+", Sdg}, {"v", V}, {"vi", Vdg}, {"vp", Vdg}, {"v+", Vdg}, {"rx", RX}, {"ry", RY}, {"rz", RZ}, {"f", SWAP}, {"if", SWAP}, {"p", Peres}, {"pi", Peresdg}, {"p+", Peresdg}, {"q", P}};
+
+        while (!is.eof()) {
+            if (!static_cast<bool>(is >> cmd)) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Failed to read command");
+            }
+            std::transform(
+                    cmd.begin(), cmd.end(), cmd.begin(),
+                    [](const unsigned char c) { return static_cast<char>(tolower(c)); });
+            ++line;
+
+            if (cmd.front() == '#') {
+                is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                continue;
+            }
+
+            if (cmd == ".end") {
+                break;
+            }
+
+            // match gate declaration
+            if (!std::regex_match(cmd, m, gateRegex)) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Unsupported gate detected: " + cmd);
+            }
+
+            // extract gate information (identifier, #controls, divisor)
+            OpType gate{};
+            if (m.str(1) == "t") { // special treatment of t(offoli) for real format
+                gate = X;
+            } else {
+                auto it = IDENTIFIER_MAP.find(m.str(1));
+                if (it == IDENTIFIER_MAP.end()) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Unknown gate identifier: " + m.str(1));
+                }
+                gate = (*it).second;
+            }
+            auto ncontrols =
+                    m.str(2).empty() ? 0 : std::stoul(m.str(2), nullptr, 0) - 1;
+            const fp lambda = m.str(3).empty() ? static_cast<fp>(0L) : static_cast<fp>(std::stold(m.str(3)));
+
+            if (gate == V || gate == Vdg || m.str(1) == "c") {
+                ncontrols = 1;
+            } else if (gate == Peres || gate == Peresdg) {
+                ncontrols = 2;
+            }
+
+            if (ncontrols >= qc->getNqubits()) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Gate acts on " + std::to_string(ncontrols + 1) +
+                                         " qubits, but only " + std::to_string(qc->getNqubits()) +
+                                         " qubits are available.");
+            }
+
+            std::string qubits;
+            if (!getline(is, qubits)) {
+                throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                         " msg: Failed read in gate definition");
+            }
+            trimCommentAndTrailingWhitespaceData(qubits);
+
+            // If we cannot determine how many gate lines are to be expected from the
+            // gate definition (i.e. the gate definition 'c a b' does not define the
+            // number of gate lines) we assume that the number of whitespaces left of
+            // the gate type define the number of gate lines.
+            std::size_t numberOfGateLines = 0;
+            if (const std::string& stringifiedNumberOfGateLines = m.str(2);
+                !stringifiedNumberOfGateLines.empty()) {
+                numberOfGateLines = static_cast<std::size_t>(
+                        std::stoul(stringifiedNumberOfGateLines, nullptr, 0));
+            } else {
+                numberOfGateLines = static_cast<std::size_t>(
+                        std::count(qubits.cbegin(), qubits.cend(), ' '));
+            }
+
+            // Current parser implementation defines number of expected control lines
+            // (nControl) as nLines (of gate definition) - 1. Controlled swap gate has
+            // at most two target lines so we define the number of control lines as
+            // nLines - 2.
+            if (gate == SWAP) {
+                if (numberOfGateLines < 2) {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             "msg: SWAP gate is expected to operate on at least "
+                                             "two qubits but only " +
+                                             std::to_string(ncontrols) + " were defined");
+                }
+                ncontrols = static_cast<uint32_t>(numberOfGateLines - 2);
+            }
+
+            std::vector<Control>            controls(ncontrols, Qubit());
+            const auto&                     gateLines = qubits.empty() ? "" : qubits.substr(1);
+            std::unordered_set<std::string> validVariableIdentLookup;
+
+            // Use the entries of the creg register map prefixed with 'c_' to determine
+            // the declared variable idents in the .variable entry
+            for (const auto& qregNameAndQubitIndexPair: qc->getClassicalRegisters()) {
+                validVariableIdentLookup.emplace(
+                        qregNameAndQubitIndexPair.first.substr(2));
+            }
+
+            // We will ignore the prefix '-' when validating a given gate line ident
+            auto processedGateLines = parseVariableNames(
+                    line, numberOfGateLines, gateLines, validVariableIdentLookup, "-");
+
+            std::size_t lineIdx = 0;
+            // get controls and target
+            for (std::size_t i = 0; i < ncontrols; ++i) {
+                std::string_view gateIdent       = processedGateLines.at(lineIdx++);
+                const bool       negativeControl = gateIdent.front() == '-';
+                if (negativeControl) {
+                    gateIdent = gateIdent.substr(1);
+                }
+
+                // Since variable qubits can either be data or ancillary qubits our search
+                // will have to be conducted in both lookups
+                if (const std::optional<Qubit> controlLineQubit =
+                            getQubitForVariableIdentFromAnyLookup(
+                                    std::string(gateIdent), qc->getQuantumRegisters(), qc->getAncillaRegisters());
+                    controlLineQubit.has_value()) {
+                    controls[i] =
+                            Control(*controlLineQubit,
+                                    negativeControl ? Control::Type::Neg : Control::Type::Pos);
+                } else {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Matching qubit for control line " +
+                                             std::string(gateIdent) + " not found!");
+                }
+            }
+
+            const auto  numberOfTargetLines = numberOfGateLines - ncontrols;
+            std::vector targetLineQubits(numberOfTargetLines, Qubit());
+            for (std::size_t i = 0; i < numberOfTargetLines; ++i) {
+                const auto& targetLineIdent = processedGateLines.at(lineIdx++);
+                // Since variable qubits can either be data or ancillary qubits our search
+                // will have to be conducted in both lookups
+                if (const std::optional<Qubit> targetLineQubit =
+                            getQubitForVariableIdentFromAnyLookup(
+                                    targetLineIdent, qc->getQuantumRegisters(), qc->getAncillaRegisters());
+                    targetLineQubit.has_value()) {
+                    targetLineQubits[i] = *targetLineQubit;
+                } else {
+                    throw std::runtime_error("[real parser] l:" + std::to_string(line) +
+                                             " msg: Matching qubit for target line " +
+                                             targetLineIdent + " not found!");
+                }
+            }
+
+            switch (gate) {
+                case I:
+                case H:
+                case Y:
+                case Z:
+                case S:
+                case Sdg:
+                case T:
+                case Tdg:
+                case V:
+                case Vdg:
+                    qc->emplace_back<StandardOperation>(
+                            Controls{controls.cbegin(), controls.cend()},
+                            targetLineQubits.front(), gate);
+                    break;
+                case X:
+                    qc->mcx(Controls{controls.cbegin(), controls.cend()},
+                            targetLineQubits.front());
+                    break;
+                case RX:
+                case RY:
+                case RZ:
+                case P:
+                    qc->emplace_back<StandardOperation>(
+                            Controls{controls.cbegin(), controls.cend()},
+                            targetLineQubits.front(), gate, std::vector{PI / (lambda)});
+                    break;
+                case SWAP:
+                case iSWAP:
+                    qc->emplace_back<StandardOperation>(
+                            Controls{controls.cbegin(), controls.cend()},
+                            Targets{targetLineQubits.cbegin(), targetLineQubits.cend()}, gate);
+                    break;
+                case Peres:
+                case Peresdg: {
+                    const auto target1 = controls.back().qubit;
+                    controls.pop_back();
+                    qc->emplace_back<StandardOperation>(
+                            Controls{controls.cbegin(), controls.cend()}, target1,
+                            targetLineQubits.front(), gate);
+                    break;
+                }
+                default:
+                    std::cerr << "Unsupported operation encountered:  " << gate << "!\n";
+                    break;
+            }
+        }
+    }
+} // namespace syrec

--- a/test/unittests/test_real_parser.cpp
+++ b/test/unittests/test_real_parser.cpp
@@ -1,0 +1,1557 @@
+#include "Definitions.hpp"
+#include "core/real/parser.hpp"
+#include "ir/Permutation.hpp"
+#include "ir/QuantumComputation.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <iomanip>
+#include <ios>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+using namespace qc;
+class RealParserTest: public testing::Test {
+public:
+    RealParserTest& usingVersion(double versionNumber) {
+        realFileContent << realHeaderVersionCommandPrefix << " " << std::fixed
+                        << std::setprecision(1) << versionNumber << "\n";
+        return *this;
+    }
+
+    RealParserTest& usingNVariables(std::size_t numVariables) {
+        realFileContent << realHeaderNumVarsCommandPrefix << " "
+                        << std::to_string(numVariables) << "\n";
+        return *this;
+    }
+
+    RealParserTest& usingVariables(
+            const std::initializer_list<std::string_view>& variableIdents) {
+        return usingVariables(variableIdents, std::nullopt);
+    }
+
+    RealParserTest&
+    usingVariables(const std::initializer_list<std::string_view>& variableIdents,
+                   const std::optional<std::string>&              optionalPostfix) {
+        pipeStringifiedCollectionToStream(realFileContent,
+                                          realHeaderVariablesCommandPrefix,
+                                          variableIdents, " ", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest& usingInitialLayout(
+            const std::initializer_list<std::string_view>& variableIdents) {
+        return usingInitialLayout(variableIdents, std::nullopt);
+    }
+
+    RealParserTest& usingInitialLayout(
+            const std::initializer_list<std::string_view>& variableIdents,
+            const std::optional<std::string>&              optionalPostfix) {
+        pipeStringifiedCollectionToStream(realFileContent,
+                                          realHeaderInitialLayoutCommandPrefix,
+                                          variableIdents, " ", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest&
+    usingInputs(const std::initializer_list<std::string_view>& inputIdents) {
+        return usingInputs(inputIdents, std::nullopt);
+    }
+
+    RealParserTest&
+    usingInputs(const std::initializer_list<std::string_view>& inputIdents,
+                const std::optional<std::string>&              optionalPostfix) {
+        pipeStringifiedCollectionToStream(realFileContent,
+                                          realHeaderInputCommandPrefix, inputIdents,
+                                          " ", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest&
+    usingOutputs(const std::initializer_list<std::string_view>& outputIdents) {
+        return usingOutputs(outputIdents, std::nullopt);
+    }
+
+    RealParserTest&
+    usingOutputs(const std::initializer_list<std::string_view>& outputIdents,
+                 const std::optional<std::string>&              optionalPostfix) {
+        pipeStringifiedCollectionToStream(realFileContent,
+                                          realHeaderOutputCommandPrefix,
+                                          outputIdents, " ", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest&
+    withConstants(const std::initializer_list<char>& constantValuePerVariable) {
+        return withConstants(constantValuePerVariable, std::nullopt);
+    }
+
+    RealParserTest&
+    withConstants(const std::initializer_list<char>& constantValuePerVariable,
+                  const std::optional<std::string>&  optionalPostfix) {
+        const std::string concatenatedConstantValues(constantValuePerVariable);
+        pipeStringifiedCollectionToStream(
+                realFileContent, realHeaderConstantsCommandPrefix + " ",
+                {concatenatedConstantValues}, "", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest& withGarbageValues(
+            const std::initializer_list<char>& isGarbageValuePerVariable) {
+        return withGarbageValues(isGarbageValuePerVariable, std::nullopt);
+    }
+
+    RealParserTest& withGarbageValues(
+            const std::initializer_list<char>& isGarbageValuePerVariable,
+            const std::optional<std::string>&  optionalPostfix) {
+        const std::string concatenatedIsGarbageValues(isGarbageValuePerVariable);
+        pipeStringifiedCollectionToStream(
+                realFileContent, realHeaderGarbageCommandPrefix + " ",
+                {concatenatedIsGarbageValues}, "", optionalPostfix);
+        return *this;
+    }
+
+    RealParserTest& withEmptyGateList() {
+        realFileContent << realHeaderGateListPrefix << "\n"
+                        << reakHeaderGateListPostfix;
+        return *this;
+    }
+
+    RealParserTest& withGates(
+            const std::initializer_list<std::string_view>& stringifiedGateList) {
+        if (stringifiedGateList.size() == 0) {
+            return withEmptyGateList();
+        }
+
+        realFileContent << realHeaderGateListPrefix;
+        for (const auto& stringifiedGate: stringifiedGateList) {
+            realFileContent << "\n"
+                            << stringifiedGate;
+        }
+
+        realFileContent << "\n"
+                        << reakHeaderGateListPostfix;
+        return *this;
+    }
+
+protected:
+    const std::string realHeaderVersionCommandPrefix       = ".version";
+    const std::string realHeaderNumVarsCommandPrefix       = ".numvars";
+    const std::string realHeaderVariablesCommandPrefix     = ".variables";
+    const std::string realHeaderInitialLayoutCommandPrefix = ".initial_layout";
+    const std::string realHeaderInputCommandPrefix         = ".inputs";
+    const std::string realHeaderOutputCommandPrefix        = ".outputs";
+    const std::string realHeaderConstantsCommandPrefix     = ".constants";
+    const std::string realHeaderGarbageCommandPrefix       = ".garbage";
+    const std::string realHeaderGateListPrefix             = ".begin";
+    const std::string reakHeaderGateListPostfix            = ".end";
+
+    static constexpr double DEFAULT_REAL_VERSION = 2.0;
+
+    const char constantValueZero = '0';
+    const char constantValueOne  = '1';
+    const char constantValueNone = '-';
+
+    const char            isGarbageState      = '1';
+    const char            isNotGarbageState   = '-';
+    static constexpr char COMMENT_LINE_PREFIX = '#';
+
+    enum class GateType : std::uint8_t { Toffoli,
+                                         V };
+
+    QuantumComputation qc;
+    std::stringstream  realFileContent;
+
+    static void pipeStringifiedCollectionToStream(
+            std::stringstream& pipedToStream, std::string_view elementsPrefix,
+            const std::initializer_list<std::string_view>& elements,
+            std::string_view                               elementDelimiter,
+            const std::optional<std::string_view>&         optionalPostfix) {
+        pipedToStream << elementsPrefix;
+        for (const auto& element: elements) {
+            pipedToStream << elementDelimiter << element;
+        }
+
+        if (optionalPostfix.has_value()) {
+            pipedToStream << optionalPostfix.value();
+        }
+
+        pipedToStream << "\n";
+    }
+
+    static std::string createComment(std::string_view commentData) {
+        return std::string(1, COMMENT_LINE_PREFIX) + std::string(commentData);
+    }
+
+    static Permutation getIdentityPermutation(std::size_t nQubits) {
+        auto identityPermutation = Permutation();
+        for (std::size_t i = 0; i < nQubits; ++i) {
+            const auto qubit = static_cast<Qubit>(i);
+            identityPermutation.insert({qubit, qubit});
+        }
+        return identityPermutation;
+    }
+
+    static std::string stringifyGateType(const GateType gateType) {
+        if (gateType == GateType::Toffoli) {
+            return "t";
+        }
+        if (gateType == GateType::V) {
+            return "v";
+        }
+
+        throw std::invalid_argument("Failed to stringify gate type");
+    }
+
+    static std::string
+    stringifyGate(const GateType                                 gateType,
+                  const std::initializer_list<std::string_view>& controlLines,
+                  const std::initializer_list<std::string_view>& targetLines) {
+        return stringifyGate(gateType, std::nullopt, controlLines, targetLines,
+                             std::nullopt);
+    }
+
+    static std::string
+    stringifyGate(const GateType                                 gateType,
+                  const std::optional<std::size_t>&              optionalNumberOfGateLines,
+                  const std::initializer_list<std::string_view>& controlLines,
+                  const std::initializer_list<std::string_view>& targetLines,
+                  const std::optional<std::string_view>&         optionalPostfix) {
+        EXPECT_TRUE(targetLines.size() > static_cast<std::size_t>(0))
+                << "Gate must have at least one line defined";
+
+        std::stringstream stringifiedGateBuffer;
+        if (controlLines.size() == 0 && !optionalNumberOfGateLines.has_value()) {
+            stringifiedGateBuffer << stringifyGateType(gateType);
+        } else {
+            stringifiedGateBuffer
+                    << stringifyGateType(gateType)
+                    << std::to_string(optionalNumberOfGateLines.value_or(
+                               controlLines.size() + targetLines.size()));
+        }
+        for (const auto& controlLine: controlLines) {
+            stringifiedGateBuffer << " " << controlLine;
+        }
+
+        for (const auto& targetLine: targetLines) {
+            stringifiedGateBuffer << " " << targetLine;
+        }
+
+        if (optionalPostfix.has_value()) {
+            stringifiedGateBuffer << optionalPostfix.value();
+        }
+
+        return stringifiedGateBuffer.str();
+    }
+};
+
+// ERROR TESTS
+TEST_F(RealParserTest, MoreVariablesThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2", "v3"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MoreInputsThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "i2", "i3"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MoreOutputsThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1", "o2", "o3"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MoreConstantsThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueZero, constantValueZero, constantValueZero})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MoreGarbageEntriesThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({isGarbageState, isNotGarbageState, isGarbageState})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MoreIdentsInInitialLayoutThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v1", "v2", "v3"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessVariablesThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessInputsThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessOutputsThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessConstantsThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueNone})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessGarbageEntriesThanNumVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({isNotGarbageState})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, LessIdentsInInitialLayoutThanVariablesDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidVariableIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"variable-1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidInputIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"test-input1", "i2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidInputIdentDefinitionInQuote) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"\"test-input1\"", "i2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidVariableIdentDefinitionInInitialLayout) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v-1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, EmptyInputIdentInQuotesNotAllowed) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "\"\""})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidOutputIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"i1", "test-output1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidOutputIdentDefinitionInQuote) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"\"test-output1\"", "o2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, EmptyOutputIdentInQuotesNotAllowed) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"\"\"", "o2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InputIdentMatchingVariableIdentIsNotAllowed) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, OutputIdentMatchingVariableIdentIsNotAllowed) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"v1", "o2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateVariableIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateInputIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "i1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateOutputIdentDefinition) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1", "o1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateVariableIdentDefinitionInInitialLayout) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v1", "v1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest,
+       MissingClosingQuoteInIoIdentifierDoesNotLeadToInfinityLoop) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"\"o1", "o1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, MissingOpeningQuoteInIoIdentifierIsDetectedAsFaulty) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1\"", "o1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidConstantStateValue) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueOne, 't'})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InvalidGarbageStateValue) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({'t', isNotGarbageState});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GateWithMoreLinesThanDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(3)
+            .usingVariables({"v1", "v2", "v3"})
+            .withGates({stringifyGate(GateType::Toffoli, std::optional(2),
+                                      {"v1", "v2"}, {"v3"}, std::nullopt)});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GateWithLessLinesThanDeclared) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(3)
+            .usingVariables({"v1", "v2", "v3"})
+            .withGates({stringifyGate(GateType::Toffoli, std::optional(3), {"v1"},
+                                      {"v3"}, std::nullopt)});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GateWithControlLineTargetingUnknownVariable) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, {"v3"}, {"v2"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GateWithTargetLineTargetingUnknownVariable) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v3"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, UnknownVariableIdentDefinitionInInitialLayout) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v4", "v1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateNumVarsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingNVariables(3)
+            .usingVariables({"v1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateVariablesDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "i2"})
+            .usingVariables({"v1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateInputsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "i2"})
+            .withConstants({constantValueOne, constantValueNone})
+            .usingOutputs({"o1", "o2"})
+            .usingInputs({"i1", "i2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateConstantsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "i2"})
+            .withConstants({constantValueOne, constantValueNone})
+            .usingOutputs({"o1", "o2"})
+            .withConstants({constantValueOne, constantValueNone})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateOutputsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1", "o2"})
+            .withGarbageValues({isGarbageState, isNotGarbageState})
+            .usingOutputs({"o1", "o2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateGarbageDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o1", "o2"})
+            .withGarbageValues({isGarbageState, isNotGarbageState})
+            .withGarbageValues({isGarbageState, isNotGarbageState})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateInitialLayoutDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v2", "v1"})
+            .withGarbageValues({isGarbageState, isNotGarbageState})
+            .usingInitialLayout({"v2", "v1"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, HeaderWithoutNumVarsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingVariables({"v1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, HeaderWithoutVariablesDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION).usingNVariables(2).withEmptyGateList();
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, ContentWithoutGateListNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, VariableDefinitionPriorToNumVarsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingVariables({"v1", "v2"})
+            .usingNVariables(2);
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InputsDefinitionPrioToVariableDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingInputs({"i1", "i2"})
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, OutputDefinitionPriorToVariableDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingOutputs({"o1", "o2"})
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, ConstantsDefinitionPriorToNumVarsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .withConstants({constantValueOne, constantValueZero})
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GarbageDefinitionPriorToNumVarsDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .withGarbageValues({isGarbageState, isGarbageState})
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, InitialLayoutPriorToVariableDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingInitialLayout({"v1", "v2"})
+            .usingVariables({"v1", "v2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, OutputsDefinitionPriorToInputDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"i2", "i1"})
+            .usingInputs({"i1", "i2"});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateControlLineInGateDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(3)
+            .usingVariables({"v1", "v2", "v3"})
+            .withGates(
+                    {stringifyGate(GateType::Toffoli, {"v1", "v2", "v1"}, {"v3"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, DuplicateTargetLineInGateDefinitionNotPossible) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(3)
+            .usingVariables({"v1", "v2", "v3"})
+            .withGates({stringifyGate(GateType::V, {"v1"}, {"v2", "v3", "v2"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, NotDefinedVariableNotUsableAsControlLine) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1", "v3"}, {"v2"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, NotDefinedVariableNotUsableAsTargetLine) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v3"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+TEST_F(RealParserTest, GateLineNotUsableAsControlAndTargetLine) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v1"})});
+
+    EXPECT_THROW(
+            qc = syrec::RealParser::import(realFileContent),
+            std::runtime_error);
+}
+
+// OK TESTS
+TEST_F(RealParserTest, ConstantValueZero) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueZero, constantValueNone})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                        stringifyGate(GateType::Toffoli, {"v2"}, {"v1"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(true, false));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(getIdentityPermutation(2)),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, ConstantValueOne) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueNone, constantValueOne})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                        stringifyGate(GateType::Toffoli, {"v2"}, {"v1"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, true));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(getIdentityPermutation(2)),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, GarbageValues) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({isNotGarbageState, isGarbageState})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                        stringifyGate(GateType::Toffoli, {"v2"}, {"v1"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(1, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, true));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false));
+
+    Permutation expectedOutputPermutation;
+    expectedOutputPermutation.emplace(static_cast<Qubit>(0),
+                                      static_cast<Qubit>(0));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, InputIdentDefinitionInQuotes) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i1", "\"test_input_1\""})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                        stringifyGate(GateType::Toffoli, {"v2"}, {"v1"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(getIdentityPermutation(2)),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, OutputIdentDefinitionInQuotes) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"\"other_output_2\"", "\"o2\""})
+            .withGates({stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                        stringifyGate(GateType::Toffoli, {"v2"}, {"v1"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(getIdentityPermutation(2)),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest,
+       InputIdentInQuotesAndMatchingOutputNotInQuotesNotConsideredEqual) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "\"o2\"", "i3", "\"o4\""})
+            .withGarbageValues({isNotGarbageState, isGarbageState, isNotGarbageState,
+                                isGarbageState})
+            .usingOutputs({"i1", "o2", "i3", "o4"})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(2, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, true, false, true));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false, false, false));
+
+    auto expectedOutputPermutation = getIdentityPermutation(4);
+    expectedOutputPermutation.erase(1);
+    expectedOutputPermutation.erase(3);
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest,
+       InputIdentNotInQuotesAndMatchingOutputInQuotesNotConsideredEqual) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "i2", "i3", "i4"})
+            .withGarbageValues({isNotGarbageState, isGarbageState, isNotGarbageState,
+                                isGarbageState})
+            .usingOutputs({"i1", "\"i1\"", "i2", "\"i4\""})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(2, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false, true, true));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false, false, false));
+
+    auto expectedOutputPermutation = getIdentityPermutation(4);
+    expectedOutputPermutation.erase(1);
+    expectedOutputPermutation.erase(3);
+    expectedOutputPermutation[2] = static_cast<Qubit>(1);
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, MatchingInputAndOutputNotInQuotes) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "i2", "i3", "i4"})
+            .withConstants({constantValueOne, constantValueNone, constantValueNone,
+                            constantValueZero})
+            .withGarbageValues({isGarbageState, isNotGarbageState, isNotGarbageState,
+                                isGarbageState})
+            .usingOutputs({"o1", "i1", "i4", "o2"})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(2, qc.getNancillae());
+    ASSERT_EQ(2, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, true, true, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(true, false, false, true));
+
+    Permutation expectedOutputPermutation;
+    expectedOutputPermutation.emplace(static_cast<Qubit>(1),
+                                      static_cast<Qubit>(0));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(2),
+                                      static_cast<Qubit>(3));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, MatchingInputAndOutputInQuotes) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "\"i2\"", "\"i3\"", "i4"})
+            .withConstants({constantValueNone, constantValueOne, constantValueZero,
+                            constantValueNone})
+            .withGarbageValues({isNotGarbageState, isNotGarbageState,
+                                isNotGarbageState, isGarbageState})
+            .usingOutputs({"i4", "\"i3\"", "\"i2\"", "o1"})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(2, qc.getNancillae());
+    ASSERT_EQ(1, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(true, false, false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, true, true, false));
+
+    Permutation expectedOutputPermutation;
+    expectedOutputPermutation.emplace(static_cast<Qubit>(0),
+                                      static_cast<Qubit>(3));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(1),
+                                      static_cast<Qubit>(2));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(2),
+                                      static_cast<Qubit>(1));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest,
+       OutputPermutationCorrectlySetBetweenMatchingInputAndOutputEntries) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "i2", "i3", "i4"})
+            .usingOutputs({"i4", "i3", "i2", "i1"})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, false, false, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false, false, false));
+
+    Permutation expectedOutputPermutation;
+    expectedOutputPermutation.emplace(static_cast<Qubit>(0),
+                                      static_cast<Qubit>(3));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(1),
+                                      static_cast<Qubit>(2));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(2),
+                                      static_cast<Qubit>(1));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(3),
+                                      static_cast<Qubit>(0));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, OutputPermutationForGarbageQubitsNotCreated) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInputs({"i1", "i2", "i3", "i4"})
+            .withGarbageValues({isNotGarbageState, isGarbageState, isGarbageState,
+                                isNotGarbageState})
+            .usingOutputs({"i4", "o1", "o2", "i1"})
+            .withGates({
+                    stringifyGate(GateType::Toffoli, {"v1"}, {"v2"}),
+                    stringifyGate(GateType::Toffoli, {"v2"}, {"v1"}),
+                    stringifyGate(GateType::Toffoli, {"v3"}, {"v4"}),
+                    stringifyGate(GateType::Toffoli, {"v4"}, {"v3"}),
+            });
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(2, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, true, true, false));
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(false, false, false, false));
+
+    Permutation expectedOutputPermutation;
+    expectedOutputPermutation.emplace(static_cast<Qubit>(0),
+                                      static_cast<Qubit>(3));
+
+    expectedOutputPermutation.emplace(static_cast<Qubit>(3),
+                                      static_cast<Qubit>(0));
+
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedOutputPermutation),
+            std::hash<Permutation>{}(qc.outputPermutation));
+}
+
+TEST_F(RealParserTest, CheckIdentityInitialLayout) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v1", "v2"})
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+
+    const Permutation expectedInitialLayout = getIdentityPermutation(2);
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedInitialLayout),
+            std::hash<Permutation>{}(qc.initialLayout));
+}
+
+TEST_F(RealParserTest, CheckNoneIdentityInitialLayout) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(4)
+            .usingVariables({"v1", "v2", "v3", "v4"})
+            .usingInitialLayout({"v4", "v2", "v1", "v3"})
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(4, qc.getNqubits());
+    Permutation expectedInitialLayout;
+
+    expectedInitialLayout.emplace(static_cast<Qubit>(0), static_cast<Qubit>(2));
+
+    expectedInitialLayout.emplace(static_cast<Qubit>(1), static_cast<Qubit>(1));
+
+    expectedInitialLayout.emplace(static_cast<Qubit>(2), static_cast<Qubit>(3));
+
+    expectedInitialLayout.emplace(static_cast<Qubit>(3), static_cast<Qubit>(0));
+    ASSERT_EQ(
+            std::hash<Permutation>{}(expectedInitialLayout),
+            std::hash<Permutation>{}(qc.initialLayout));
+}
+
+TEST_F(RealParserTest, GateWithoutExplicitNumGateLinesDefinitionOk) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::V, {}, {"v1", "v2"})});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNops());
+}
+
+TEST_F(RealParserTest, VariableDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"},
+                            std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+}
+
+TEST_F(RealParserTest, VariableDefinitionWithWhitespacePostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"}, std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+}
+
+TEST_F(RealParserTest, InitialLayoutDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v2", "v1"},
+                                std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, InitialLayoutDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInitialLayout({"v2", "v1"}, std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, InputsDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i2", "i1"},
+                         std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, InputsDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingInputs({"i2", "i1"}, std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, ConstantsDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueOne, constantValueNone},
+                           std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(true, false));
+}
+
+TEST_F(RealParserTest, ConstantsDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withConstants({constantValueOne, constantValueNone},
+                           std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNancillae());
+    ASSERT_EQ(0, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getAncillary(),
+                testing::ElementsAre(true, false));
+}
+
+TEST_F(RealParserTest, OutputsDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o2", "o1"},
+                          std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, OutputsDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .usingOutputs({"o2", "o1"}, std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+}
+
+TEST_F(RealParserTest, GarbageDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({isGarbageState, isNotGarbageState},
+                               std::make_optional(createComment(" a test comment")))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(1, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(true, false));
+}
+
+TEST_F(RealParserTest, GarbageDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGarbageValues({isNotGarbageState, isGarbageState},
+                               std::make_optional(" \t\t \t"))
+            .withEmptyGateList();
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(0, qc.getNancillae());
+    ASSERT_EQ(1, qc.getNgarbageQubits());
+    ASSERT_THAT(qc.getGarbage(),
+                testing::ElementsAre(false, true));
+}
+
+TEST_F(RealParserTest, GateDefinitionWithCommentLineAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(
+                    GateType::Toffoli, std::nullopt, {"v1"}, {"v2"},
+                    std::make_optional(createComment(" a test comment")))});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNops());
+}
+
+TEST_F(RealParserTest, GateDefinitionWithWhitespaceAsPostfix) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables({"v1", "v2"})
+            .withGates({stringifyGate(GateType::Toffoli, std::nullopt, {"v1"}, {"v2"},
+                                      std::make_optional(" \t\t \t"))});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNops());
+}
+
+TEST_F(RealParserTest, CombinationOfCommentLineAndWhitespacePostfixAllowed) {
+    usingVersion(DEFAULT_REAL_VERSION)
+            .usingNVariables(2)
+            .usingVariables(
+                    {"v1", "v2"},
+                    std::make_optional(" \t\t \t" + createComment(" a test comment")))
+            .withGates({stringifyGate(
+                    GateType::Toffoli, std::nullopt, {"v1"}, {"v2"},
+                    std::make_optional(" \t\t \t" + createComment(" a test comment")))});
+
+    EXPECT_NO_THROW(
+            qc = syrec::RealParser::import(realFileContent));
+
+    ASSERT_EQ(2, qc.getNqubits());
+    ASSERT_EQ(1, qc.getNops());
+}

--- a/test/unittests/test_real_parser.cpp
+++ b/test/unittests/test_real_parser.cpp
@@ -11,7 +11,6 @@
 #include <initializer_list>
 #include <iomanip>
 #include <ios>
-#include <memory>
 #include <optional>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
## Description

This moves the `.real` parser from MQT Core, where it has been removed in https://github.com/cda-tum/mqt-core/pull/822,  to this repository.
As there are no previous connection points to the SyReC repository, this is relatively standalone for now.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
